### PR TITLE
fix: add types to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "exports": {
     ".": {
       "require": "./dist/vue-rewards.umd.cjs",
-      "import": "./dist/vue-rewards.js"
+      "import": "./dist/vue-rewards.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "repository": {


### PR DESCRIPTION
When changing my moduleResolution to "bundler", I suddenly get a TypeScript error when trying to import vue-rewards:

>Could not find a declaration file for module 'vue-rewards'.

Adding types to the exports section resolves this issue.

```js
  "exports": {
    ".": {
      "require": "./dist/vue-rewards.umd.cjs",
      "import": "./dist/vue-rewards.js",
      "types": "./dist/index.d.ts"
    }
  },
```

